### PR TITLE
Updated to use urllib.parse.quote

### DIFF
--- a/searchplugin.py
+++ b/searchplugin.py
@@ -2,7 +2,7 @@ import gi
 gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk
 from gi.repository import Gdk
-import urllib
+import urllib.parse
 import terminatorlib.plugin as plugin
 import re
 
@@ -29,7 +29,7 @@ class SearchPlugin(plugin.Plugin):
         if not self.searchstring:
             return
         base_uri = "https://www.google.com/search?q=%s"
-        uri = base_uri % urllib.quote(self.searchstring.encode("utf-8"))
+        uri = base_uri % urllib.parse.quote(self.searchstring.encode("utf-8"))
         gtk.show_uri(None, uri, Gdk.CURRENT_TIME)
         
     def callback(self, menuitems, menu, terminal):


### PR DESCRIPTION
Per https://docs.python.org/2/library/urllib.html, urllib.quote is no longer available. You must use urllib.quote.parse now.